### PR TITLE
Changed 'prefix' to 'kind' and added functionality to change datastore kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const DatastoreStore = require('@google-cloud/connect-datastore')(session);
 app.use(session({
   store: new DatastoreStore({
     dataset: Datastore({
-      prefix: 'express-sessions',
+      kind: 'express-sessions',
 
       // For convenience, @google-cloud/datastore automatically looks for the
       // GCLOUD_PROJECT environment variable. Or you can explicitly pass in a

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -24,7 +24,7 @@ app.use(
   session({
     store: new DatastoreStore({
       dataset: Datastore({
-        prefix: 'express-sessions',
+        kind: 'express-sessions',
 
         // For convenience, @google-cloud/datastore automatically looks for the
         // GCLOUD_PROJECT environment variable. Or you can explicitly pass in a

--- a/src/index.js
+++ b/src/index.js
@@ -26,10 +26,11 @@ module.exports = function(session) {
       if (!this.ds) {
         throw new Error('No dataset provided to Datastore Session.');
       }
+      this.kind = options.kind || 'Session';
     }
 
     get(sid, callback) {
-      this.ds.get(this.ds.key(['Session', sid]), (err, entity) => {
+      this.ds.get(this.ds.key([this.kind, sid]), (err, entity) => {
         if (err) {
           return callback(err);
         }
@@ -59,7 +60,7 @@ module.exports = function(session) {
 
       this.ds.save(
         {
-          key: this.ds.key(['Session', sid]),
+          key: this.ds.key([this.kind, sid]),
           data: [
             {
               name: 'data',
@@ -73,7 +74,7 @@ module.exports = function(session) {
     }
 
     destroy(sid, fn) {
-      this.ds.delete(this.ds.key(['Session', sid]), fn);
+      this.ds.delete(this.ds.key([this.kind, sid]), fn);
     }
   }
   return DatastoreStore;


### PR DESCRIPTION
Fixes #7

* Prefix does nothing, and is not a datastore keyword. Changed it to `kind` as that is the actual keyword
* Also updated the code so that `'Session'` is overridden if the `kind` option is set

- [👍] Tests and linter pass
- [👍] Code coverage does not decrease (if any source code was changed)
- [👍] Appropriate docs were updated (if necessary)

There is not much test coverage, so a test would need to be made by an owner