### PR TITLE
Release @google-cloud/connect-datastore v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
 - Update code style and switch to using Semistandard for linting
 - Added `yarn.lock` file
 - Updated licensing, authors, contributors, readme
+## v2.0.1
+
+12-11-2018 21:18 PST
+
+### Internal / Testing Changes
+- chore(build): inject yoshi automation key ([#66](https://github.com/googleapis/nodejs-datastore-session/pull/66))
+- chore: update nyc and eslint configs ([#65](https://github.com/googleapis/nodejs-datastore-session/pull/65))
+- chore: fix publish.sh permission +x ([#62](https://github.com/googleapis/nodejs-datastore-session/pull/62))
+
 ## v2.0.0
 
 12-10-2018 15:18 PST

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/connect-datastore",
   "description": "Google Cloud Datastore session store for Express/Connect",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "main": "./src/index.js",

--- a/samples/package.json
+++ b/samples/package.json
@@ -11,7 +11,7 @@
     "test": "mocha system-test"
   },
   "dependencies": {
-    "@google-cloud/connect-datastore": "^2.0.0",
+    "@google-cloud/connect-datastore": "^2.0.1",
     "@google-cloud/datastore": "^2.0.0",
     "express": "^4.16.4",
     "express-session": "^1.15.6"


### PR DESCRIPTION
This pull request was generated using releasetool.