### PR TITLE
Release @google-cloud/connect-datastore v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@
 - Update code style and switch to using Semistandard for linting
 - Added `yarn.lock` file
 - Updated licensing, authors, contributors, readme
+## v2.0.2
+
+02-15-2019 23:34 PST
+
+### Dependencies
+- fix(deps): update dependency @google-cloud/datastore to v3 ([#70](https://github.com/googleapis/nodejs-datastore-session/pull/70))
+
+### Documentation
+- docs: fix quickstart code for 3.0 ([#83](https://github.com/googleapis/nodejs-datastore-session/pull/83))
+- docs: update links in contrib guide ([#80](https://github.com/googleapis/nodejs-datastore-session/pull/80))
+- docs: update contributing path in README ([#76](https://github.com/googleapis/nodejs-datastore-session/pull/76))
+- docs: move CONTRIBUTING.md to root ([#75](https://github.com/googleapis/nodejs-datastore-session/pull/75))
+- docs: add lint/fix example to contributing guide ([#73](https://github.com/googleapis/nodejs-datastore-session/pull/73))
+
+### Internal / Testing Changes
+- build: use linkinator for docs test ([#79](https://github.com/googleapis/nodejs-datastore-session/pull/79))
+- build: create docs test npm scripts ([#78](https://github.com/googleapis/nodejs-datastore-session/pull/78))
+- build: test using @grpc/grpc-js in CI ([#77](https://github.com/googleapis/nodejs-datastore-session/pull/77))
+- chore(deps): update dependency eslint-config-prettier to v4 ([#72](https://github.com/googleapis/nodejs-datastore-session/pull/72))
+- build: ignore googleapis.com in doc link check ([#71](https://github.com/googleapis/nodejs-datastore-session/pull/71))
+
 ## v2.0.1
 
 12-11-2018 21:18 PST

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/connect-datastore",
   "description": "Google Cloud Datastore session store for Express/Connect",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "main": "./src/index.js",

--- a/samples/package.json
+++ b/samples/package.json
@@ -11,7 +11,7 @@
     "test": "mocha system-test"
   },
   "dependencies": {
-    "@google-cloud/connect-datastore": "^2.0.1",
+    "@google-cloud/connect-datastore": "^2.0.2",
     "@google-cloud/datastore": "^3.0.0",
     "express": "^4.16.4",
     "express-session": "^1.15.6"


### PR DESCRIPTION
This pull request was generated using releasetool.  Fixes #84 