### PR TITLE
feat: add option expirationMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ app.use(session({
     dataset: new Datastore({
       kind: 'express-sessions',
 
+      // Optional: expire the session after this many milliseconds.
+      // note: datastore does not automatically delete all expired sessions
+      // you may want to run separate cleanup requests to remove expired sessions
+      // 0 means do not expire
+      expirationMs: 0,
+
       // For convenience, @google-cloud/datastore automatically looks for the
       // GCLOUD_PROJECT environment variable. Or you can explicitly pass in a
       // project ID here:
@@ -54,6 +60,15 @@ app.use(session({
   secret: 'my-secret'
 }));
 ```
+
+## Expiration
+If a session is fetched with the delta between the createdAt time and current
+time greater than expirationMs, the session will not be returned and will
+instead be destroyed.
+
+Datastore does not support a `ttl`, and tokens are only deleted if a session
+is fetched. You will likely want to implement logic to occasionally delete
+expired sessions.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,15 @@ const DatastoreStore = require('@google-cloud/connect-datastore')(session);
 
 app.use(session({
   store: new DatastoreStore({
-    dataset: new Datastore({
-      kind: 'express-sessions',
+    kind: 'express-sessions',
 
-      // Optional: expire the session after this many milliseconds.
-      // note: datastore does not automatically delete all expired sessions
-      // you may want to run separate cleanup requests to remove expired sessions
-      // 0 means do not expire
-      expirationMs: 0,
+    // Optional: expire the session after this many milliseconds.
+    // note: datastore does not automatically delete all expired sessions
+    // you may want to run separate cleanup requests to remove expired sessions
+    // 0 means do not expire
+    expirationMs: 0,
+
+    dataset: new Datastore({
 
       // For convenience, @google-cloud/datastore automatically looks for the
       // GCLOUD_PROJECT environment variable. Or you can explicitly pass in a

--- a/system-test/session.js
+++ b/system-test/session.js
@@ -32,37 +32,87 @@ before(() => {
   );
 });
 
-const store = new DatastoreStore({
-  dataset: new Datastore(),
-});
-
-it('Should return an empty session', function(done) {
-  store.get('123', function(err, session) {
-    assert.ifError(err);
-    assert.strictEqual(session, undefined);
-    done();
+describe('works with no expiration', () => {
+  const store = new DatastoreStore({
+    dataset: new Datastore(),
   });
-});
 
-it('Should create and retrieve a session', function(done) {
-  store.set('123', {foo: 'bar'}, function(err) {
-    assert.ifError(err);
-    store.get('123', function(err, session) {
+  it('Should return an empty session', function(done) {
+    store.get('id1', function(err, session) {
       assert.ifError(err);
-      assert.deepStrictEqual(session, {foo: 'bar'});
+      assert.strictEqual(session, undefined);
       done();
+    });
+  });
+
+  it('Should create and retrieve a session', function(done) {
+    store.set('id1', {foo: 'bar'}, function(err) {
+      assert.ifError(err);
+      store.get('id1', function(err, session) {
+        assert.ifError(err);
+        assert.deepStrictEqual(session, {foo: 'bar'});
+        done();
+      });
+    });
+  });
+
+  it('Should destroy a session', function(done) {
+    store.destroy('id1', function(err) {
+      assert.ifError(err);
+      assert.strictEqual(err, null);
+      store.get('id1', function(err, session) {
+        assert.ifError(err);
+        assert.strictEqual(session, undefined);
+        done();
+      });
     });
   });
 });
 
-it('Should destroy a session', function(done) {
-  store.destroy('123', function(err) {
-    assert.ifError(err);
-    assert.strictEqual(err, null);
-    store.get('123', function(err, session) {
+describe('expired session is not returned', () => {
+  const store = new DatastoreStore({
+    dataset: new Datastore(),
+    expirationMs: 1,
+  });
+
+  it('Should create but not retrieve an expired session', function(done) {
+    store.set('id2', {foo: 'bar'}, function(err) {
       assert.ifError(err);
-      assert.strictEqual(session, undefined);
-      done();
+      store.get('id2', function(err, session) {
+        assert.ifError(err);
+        assert.deepStrictEqual(session, undefined);
+        done();
+      });
+    });
+  });
+});
+
+describe('unexpired session is returned', () => {
+  const store = new DatastoreStore({
+    dataset: new Datastore(),
+    expirationMs: 10000,
+  });
+
+  it('Should create and retrieve a session', function(done) {
+    store.set('id3', {foo: 'bar'}, function(err) {
+      assert.ifError(err);
+      store.get('id3', function(err, session) {
+        assert.ifError(err);
+        assert.deepStrictEqual(session, {foo: 'bar'});
+        done();
+      });
+    });
+  });
+
+  it('Should destroy a session', function(done) {
+    store.destroy('id3', function(err) {
+      assert.ifError(err);
+      assert.strictEqual(err, null);
+      store.get('id3', function(err, session) {
+        assert.ifError(err);
+        assert.strictEqual(session, undefined);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
Please review. Also I could not get the code coverage tool nyc to give useful output, could you provide any help there?

[Edited 2019-08-25, see comment below for details]
Stores createdAt timestamp sibling to session data, under ds session key
If an expired session is retrieved it will be deleted and not returned

* update README
* bump minor version
* add system tests

Fixes googleapis/nodejs-datastore-session#8

- [X] Tests and linter pass (tests pass, linter has same failures as before PR)
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)
