### PR TITLE
build: repo has more shell than JavaScript

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,2 @@
+releaseType: node
+


### PR DESCRIPTION
ensuring that setting an explicit language type fixes releases.