### PR TITLE
fix(docs): environment variables should be read before defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ app.use(session({
       // For convenience, @google-cloud/datastore automatically looks for the
       // GCLOUD_PROJECT environment variable. Or you can explicitly pass in a
       // project ID here:
-      projectId: 'YOUR_PROJECT_ID' || process.env.GCLOUD_PROJECT,
+      projectId: process.env.GCLOUD_PROJECT || 'YOUR_PROJECT_ID',
 
       // For convenience, @google-cloud/datastore automatically looks for the
       // GOOGLE_APPLICATION_CREDENTIALS environment variable. Or you can
       // explicitly pass in that path to your key file here:
-      keyFilename: '/path/to/keyfile.json' || process.env.GOOGLE_APPLICATION_CREDENTIALS
+      keyFilename: process.env.GOOGLE_APPLICATION_CREDENTIALS || '/path/to/keyfile.json', 
     })
   }),
   secret: 'my-secret'


### PR DESCRIPTION
In the original examples:

      projectId: 'YOUR_PROJECT_ID' || process.env.GCLOUD_PROJECT,

The environment variable will never be used.  Instead, it should come first:

      projectId: process.env.GCLOUD_PROJECT || 'YOUR_PROJECT_ID',

Fixes #150 