### PR TITLE
fix(types): SessionData was removed from Express type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export class DatastoreStore extends expressSession.Store {
   kind: string;
   expirationMs: number;
   constructor(options: DataStoreOptions = {}) {
-    super(options);
+    super();
     this.ds = (options.dataset || options.datastore)!;
     if (!this.ds) {
       throw new Error('No dataset provided to Datastore Session.');
@@ -55,7 +55,10 @@ export class DatastoreStore extends expressSession.Store {
 
   get = (
     sid: string,
-    callback: (err: Error | null, session?: Express.SessionData | null) => void
+    callback: (
+      err: Error | null,
+      session?: expressSession.SessionData | null
+    ) => void
   ) => {
     this.ds.get(this.ds.key([this.kind, sid]), (err, entity) => {
       if (err) {
@@ -96,7 +99,7 @@ export class DatastoreStore extends expressSession.Store {
 
   set = (
     sid: string,
-    sess: Express.SessionData,
+    sess: expressSession.SessionData,
     callback?: (err: Error | null) => void
   ) => {
     callback = callback || (() => {});

--- a/system-test/session.ts
+++ b/system-test/session.ts
@@ -16,6 +16,7 @@ import * as assert from 'assert';
 import {describe, it} from 'mocha';
 import {DatastoreStore} from '../src';
 import {Datastore} from '@google-cloud/datastore';
+import {SessionData} from 'express-session';
 
 describe('works with no expiration', () => {
   const store = new DatastoreStore({
@@ -31,7 +32,7 @@ describe('works with no expiration', () => {
   });
 
   it('Should create and retrieve a session', done => {
-    store.set('id1', ({foo: 'bar'} as {}) as Express.SessionData, err => {
+    store.set('id1', ({foo: 'bar'} as {}) as SessionData, err => {
       assert.ifError(err);
       store.get('id1', (err, session) => {
         assert.ifError(err);
@@ -61,7 +62,7 @@ describe('expired session is not returned', () => {
   });
 
   it('Should create but not retrieve an expired session', done => {
-    store.set('id2', ({foo: 'bar'} as {}) as Express.SessionData, err => {
+    store.set('id2', ({foo: 'bar'} as {}) as SessionData, err => {
       assert.ifError(err);
       store.get('id2', (err, session) => {
         assert.ifError(err);
@@ -79,7 +80,7 @@ describe('unexpired session is returned', () => {
   });
 
   it('Should create and retrieve a session', done => {
-    store.set('id3', ({foo: 'bar'} as {}) as Express.SessionData, err => {
+    store.set('id3', ({foo: 'bar'} as {}) as SessionData, err => {
       assert.ifError(err);
       store.get('id3', (err, session) => {
         assert.ifError(err);


### PR DESCRIPTION
This should fix the nightly synth failures, as well as #246

Fixes #246 