### PR TITLE
chore: update .repo-metadata.json to make the linter happy

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -3,10 +3,11 @@
   "name_pretty": "Google Cloud Datastore Session",
   "product_documentation": "https://cloud.google.com/datastore",
   "client_documentation": "https://github.com/googleapis/nodejs-datastore-session/blob/master/README.md",
-  "release_level": "GA",
+  "release_level": "stable",
   "language": "nodejs",
   "repo": "googleapis/nodejs-datastore-session",
   "distribution_name": "@google-cloud/connect-datastore",
   "api_id": "datastore.googleapis.com",
-  "codeowner_team": "@googleapis/firestore-dpe"
+  "codeowner_team": "@googleapis/firestore-dpe",
+  "library_type": "INTEGRATION"
 }


### PR DESCRIPTION
Fixed https://github.com/googleapis/nodejs-datastore-session/issues/289 by updating "release_level" to "stable" instead of GA and adding the "library_type" field. 
